### PR TITLE
Fixing a few issues with `!bag`

### DIFF
--- a/Collections/New Bag/bag/bag.alias
+++ b/Collections/New Bag/bag/bag.alias
@@ -677,6 +677,7 @@ def limit_length(input_values: SafeList|str|SafeDict, limit: int=100) -> str:
                     string+=value_string
         case 'SafeDict':
             string += "{"
+            max_index = len(input_values)-1
             for i, item in enumerate(input_values.items()):
                 x, y = item
                 if not i:
@@ -694,7 +695,7 @@ def limit_length(input_values: SafeList|str|SafeDict, limit: int=100) -> str:
                     return string + x_string + "..."
                 else:
                     string += f"{x_string} {y_string}"
-        case 'str'|'int':
+        case 'str'|'int'|'float':
             if len(str(input_values))>limit:
                 return str(input_values)[:tlimit]+"..."
             else:

--- a/Collections/New Bag/bag/bag.alias
+++ b/Collections/New Bag/bag/bag.alias
@@ -733,7 +733,7 @@ text = []
 success = -1
 input_name = None
 bagsLoaded = load_bags()
-openMode = 'All'
+openMode = 'all'
 
 # match the input to a subcommand
 match args_list:
@@ -888,7 +888,7 @@ match args_list:
                 fullcost = ''.join(price) or typeof(weightDict.get(item.lower())) == 'SafeDict' and weightDict.get(item.lower(),{}).get("cost") or f"0{COIN_TYPES[1 if len(COIN_TYPES)>1 else 0]}"
                 num = int(''.join([x for x in fullcost if x.isdecimal()]))
                 coin = ''.join([x for x in fullcost]).lstrip(str(num))
-                bundle = typeof(weightDict.get(item.lower())) == 'SafeDict' and weightDict.get(item.lower(),{}).get("bundle",1) or 1
+                bundle = typeof(weightDict.get(item.lower())) == 'SafeDict' and weightDict.get(item.lower(),{}).get("bundle") or 1
                 quantity = ceil(float(quantity) / bundle) * bundle
                 cost = -num * quantity
                 coins, error = modify_coins(bagsLoaded, coin, cost)
@@ -998,9 +998,9 @@ match args_list:
         if not input_name:
             input_name = ' '.join(args)
         
-        openMode = "One" if input_name else openMode
         focus = get_bag(bagsLoaded, input_name) if input_name else focus
-        title_bag = f"""their {focus[0]}""" if input_name else "a bag"
+        openMode = "One" if focus else "All"
+        title_bag = f"""their {focus[0]}""" if focus else "a bag"
         text.append(f"""-title ＂{name}{[f"'s bags",f" looks inside {title_bag}"][bool(focus)]}＂""")
 
 # don't display bags if viewing help

--- a/Collections/New Bag/bag/bag.alias
+++ b/Collections/New Bag/bag/bag.alias
@@ -392,7 +392,7 @@ def rename_bag(bags_dict: SafeDict, old_name, new_name) -> (str, str):
     bags_dict[new_name] = bags_dict.pop(old_bag[0])
     return (old_bag[0], new_name)
 
-def swap_pos(bagsLoaded: SafeList, bag_name, position=1) -> int:
+def swap_pos(bagsLoaded: SafeList, bag_name, position=1) -> (str, int):
     """
     Swaps the position of a bag in the display
     Returns the new position
@@ -404,7 +404,7 @@ def swap_pos(bagsLoaded: SafeList, bag_name, position=1) -> int:
     bagsLoaded.remove([bag[0], bag[1]])
     position = max(min(len(bagsLoaded), position), 1)
     bagsLoaded.insert(position-1, bag)
-    return position
+    return bag[0], position
 
 def delete_bag(bagsLoaded: SafeList, bag_name) -> (str, bool):
     """
@@ -823,7 +823,7 @@ match args_list:
             input_name = args.pop(0)
         position = int(args[0]) if args and args[0].isdecimal() else 0
         if input_name:
-            position = swap_pos(bagsLoaded, input_name, position)
+            input_name, position = swap_pos(bagsLoaded, input_name, position)
             success = save_bags(bagsLoaded)
         title_bag = f"""their {input_name}""" if input_name else "a bag"
         text.append(f"""-title ＂{name}{[" has nothing to swap",f" swaps {title_bag} to position {position}",f" fails to swap {title_bag}"][success]}＂""")

--- a/Collections/New Bag/bag/bag.alias
+++ b/Collections/New Bag/bag/bag.alias
@@ -998,6 +998,7 @@ match args_list:
         if not input_name:
             input_name = ' '.join(args)
         
+        openMode = "One" if input_name else openMode
         focus = get_bag(bagsLoaded, input_name) if input_name else focus
         title_bag = f"""their {focus[0]}""" if input_name else "a bag"
         text.append(f"""-title ＂{name}{[f"'s bags",f" looks inside {title_bag}"][bool(focus)]}＂""")

--- a/Collections/New Bag/bag/bag.alias
+++ b/Collections/New Bag/bag/bag.alias
@@ -733,7 +733,7 @@ text = []
 success = -1
 input_name = None
 bagsLoaded = load_bags()
-openMode = 'all'
+openMode = 'All'
 
 # match the input to a subcommand
 match args_list:

--- a/Collections/New Bag/bag/bag.alias
+++ b/Collections/New Bag/bag/bag.alias
@@ -888,7 +888,7 @@ match args_list:
                 fullcost = ''.join(price) or typeof(weightDict.get(item.lower())) == 'SafeDict' and weightDict.get(item.lower(),{}).get("cost") or f"0{COIN_TYPES[1 if len(COIN_TYPES)>1 else 0]}"
                 num = int(''.join([x for x in fullcost if x.isdecimal()]))
                 coin = ''.join([x for x in fullcost]).lstrip(str(num))
-                bundle = typeof(weightDict.get(item.lower())) == 'SafeDict' and weightDict.get(item.lower(),{}).get("bundle",1)
+                bundle = typeof(weightDict.get(item.lower())) == 'SafeDict' and weightDict.get(item.lower(),{}).get("bundle",1) or 1
                 quantity = ceil(float(quantity) / bundle) * bundle
                 cost = -num * quantity
                 coins, error = modify_coins(bagsLoaded, coin, cost)


### PR DESCRIPTION
### What Alias/Snippet is this for?
`bag`

### Summary
`!bag vars` was throwing a "max_index is not defined" error.
Once that was fixed, I noticed a formatting error in the coinWeighs current value display and fixed that by adding float handling to `limit_length`

Trying to view one bag with `!bag view` was still showing all bags. Overriding the openMode to show only the bag of interest resolved the issue. When openMode was set to None (ostensibly hiding all bags when adding or removing contents) it hid all bags even during normal `!bag` (which should presumably show all bags). Turns out the default openMode behavior didn't match one of the options, so the display_bag function was defaulting to the setting (None) when trying to display. Correcting from 'all' to 'All' fixes the issue

`!bag buy` threw a divide by zero error if the item being bought doesn't exactly match an item in the weightDict. Defaulting bundle to 1 if the weightDict.get fails fixed the issue.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
- [x] I properly commented my code where appropriate